### PR TITLE
PHP 8.1 Compatibility

### DIFF
--- a/PHPmod.c
+++ b/PHPmod.c
@@ -1,9 +1,15 @@
 #include "lpsolvecaller.h"
 
-extern PHP_FUNCTION(drivername);
+extern PHP_FUNCTION(lpsolve);
+
+
+/* argument information */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_fake_php8, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, identifier, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 static zend_function_entry php_phplpsolve55_functions[] = {
-    PHP_FE(drivername, NULL)
+    PHP_FE(lpsolve, arginfo_fake_php8)
     { NULL, NULL, NULL }
 };
 
@@ -171,7 +177,7 @@ static char *empty = ""; /* ok to be static */
 
 int ErrMsgTxt(structlpsolvecaller *lpsolvecaller, char *str)
 {
-        php_error_docref(NULL TSRMLS_CC, E_ERROR, "%s", str);
+        php_error_docref(NULL, E_ERROR, "%s", str);
         return(0);
 }
 

--- a/hash.c
+++ b/hash.c
@@ -8,7 +8,6 @@
 
 #include <sys/types.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 
 #include "hash.h"

--- a/hash.h
+++ b/hash.h
@@ -23,13 +23,14 @@ typedef struct _hashtable
 extern "C" {
 #endif
 
-hashtable *create_hash_table(int size, int base);
-void      free_hash_table(hashtable *ht);
-hashelem  *findhash(const char *name, hashtable *ht);
-hashelem  *puthash(const char *name, int index, hashelem **list, hashtable *ht);
-void      drophash(const char *name, hashelem **list, hashtable *ht);
-void      free_hash_item(hashelem **hp);
-hashtable *copy_hash_table(hashtable *ht, hashelem **list, int newsize);
+static inline hashtable *create_hash_table(int size, int base);
+static inline void      free_hash_table(hashtable *ht);
+static inline hashelem  *findhash(const char *name, hashtable *ht);
+static inline hashelem  *puthash(const char *name, int index, hashelem **list, hashtable *ht);
+static inline void      drophash(const char *name, hashelem **list, hashtable *ht);
+static inline void      free_hash_item(hashelem **hp);
+static inline hashtable *copy_hash_table(hashtable *ht, hashelem **list, int newsize);
+static inline int       hashval(const char *string, int size);
 
 #ifdef __cplusplus
  }


### PR DESCRIPTION
  - NOTE: This branch is no longer compatible with PHP <8
  - Updated `php_error_docref` call to pass untyped `NULL` instead of deprecated (as of PHP 7) and removed (as of PHP 8) `TSRMLS_CC NULL`
  - Inlined hash table and element definitions to improve compilation for Linux and BDS targets
  - Removed superfluous include of `malloc.h`
  - Updated externalized definition of the `lpsolve` PHP function and its arguments to be stricter